### PR TITLE
Work around xarray align bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md') as readme_file:
 requirements = [
     "numpy",
     "pandas",
-    "xarray",
+    "xarray==0.16.1", # a bug introduced in 0.16.2 causes align to handle MultiIndex wrong
     # test_requirements
     "pytest",
 ]

--- a/tests/test_assemblies.py
+++ b/tests/test_assemblies.py
@@ -154,7 +154,19 @@ class TestSubclassing:
             },
             dims=['a', 'b']
         )
-        xr.align(da1, da2, join="outer")
+        assert hasattr(da1, "up")
+        assert da1.coords.variables["a"].level_names == ["up", "down"]
+        assert da1["a"].variable.level_names == ["up", "down"]
+        assert da1["up"] is not None
+        aligned1, aligned2 = xr.align(da1, da2, join="outer")
+        assert hasattr(aligned1, "up")
+        assert aligned1.coords.variables["a"].level_names == ["up", "down"]
+        assert aligned1["a"].variable.level_names == ["up", "down"]
+        assert aligned1["up"] is not None
+        assert hasattr(aligned2, "up")
+        assert aligned2.coords.variables["a"].level_names == ["up", "down"]
+        assert aligned2["a"].variable.level_names == ["up", "down"]
+        assert aligned2["up"] is not None
 
 
 class TestIndex:

--- a/tests/test_assemblies.py
+++ b/tests/test_assemblies.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 import xarray as xr
 from xarray import DataArray
 
@@ -122,7 +123,38 @@ class TestSubclassing:
         with pytest.raises(TypeError) as te:
             d = xr.DataArray(0, None, None, None, None, None, None, False)
         assert "but 9" in str(te.value)
-        # If they move fastpath to another spot in the list I guess it's tough.  
+        # If they move fastpath to another spot in the list I guess it's tough.
+
+    def test_align(self):
+        name = "foo",
+        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15], [16, 17, 18]]
+        mi1 = pd.MultiIndex.from_arrays([
+            ['alpha', 'alpha', 'beta', 'beta', 'beta', 'beta'],
+            [1, 2, 3, 4, 5, 6]
+        ], names=["up", "down"])
+        mi2 = pd.MultiIndex.from_arrays([
+            ['alpha', 'alpha', 'beta', 'beta', 'gamma', 'gamma'],
+            [1, 2, 3, 4, 5, 6]
+        ], names=["up", "down"])
+        da1 = DataArray(
+            name=name,
+            data=data,
+            coords={
+                'a': mi1,
+                'b': ['x', 'y', 'z']
+            },
+            dims=['a', 'b']
+        )
+        da2 = DataArray(
+            name=name,
+            data=data,
+            coords={
+                'a': mi2,
+                'b': ['x', 'y', 'z']
+            },
+            dims=['a', 'b']
+        )
+        xr.align(da1, da2, join="outer")
 
 
 class TestIndex:


### PR DESCRIPTION
A bug in xarray 0.16.2 caused tests to fail in brainscore.  Added a test to replicate that in brainio_base, and fixed xarray at 0.16.1 for now.  