### PR TITLE
Travis CI includes a preinstalled but outdated version of numpy (1.16…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 3.6
+  - 3.7
 matrix:  # python 3.7 workaround: https://github.com/travis-ci/travis-ci/issues/9815
   include:
     - python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "numpy",
-    "pandas",
+    "numpy>=1.16.5",
+    "pandas>=1.2.0",
     "xarray==0.16.1", # a bug introduced in 0.16.2 causes align to handle MultiIndex wrong
     # test_requirements
     "pytest",


### PR DESCRIPTION
….4), so if we don't specify version, pip sees that numpy is already installed and does nothing.  That became a problem when pandas 1.2 was released, which requires numpy 1.16.5 or newer, because Travis doesn't include pandas, so pip went and got the latest.  Also, no reason to use the 3.6 VM, bumping to 3.7.